### PR TITLE
respect `is_active` from miniverse #35

### DIFF
--- a/update-data.py
+++ b/update-data.py
@@ -88,6 +88,8 @@ map_json = json.loads(response.read().decode(response.info().get_param('charset'
 mylist = []
 for i in map_json['installations']:
     foo = i
+    if not i['is_active']:
+        continue
     o = urlparse(i['url'])
     i['hostname'] = o.hostname
     if i['hostname'] in metrics_list:


### PR DESCRIPTION
closes #35 

As we build the final `mylist` array of installations that gets turned into `data/data.json` this pull request allows us to skip over any installation that isn't marked as active in miniverse.

That is to say, inactive installations are not added to the array and therefor not displayed on the map.