### PR TITLE
remove https://dataverse.arch.be from map until active #30

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -589,13 +589,6 @@
       "contact_email": "dataverse@scholarsportal.info"
     },
     {
-      "name": "SODAtaverse",
-      "description": "",
-      "lat": 50.842521,
-      "lng": 4.356647,
-      "hostname": "dataverse.arch.be"
-    },
-    {
       "name": "Texas Data Repository Dataverse",
       "description": "A statewide archive of research data from Texas Digital Library (TDL) member institutions.",
       "lat": 30.307182,


### PR DESCRIPTION
closes #30 

I figure we can close #30 for now and re-open it or open a fresh issue when https://dataverse.arch.be is flagged as "active" and ready to be on the map.