### PR TITLE
add script to convert data.json to a TSV file #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dataverse-installations.tsv

--- a/json2tsv.py
+++ b/json2tsv.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import json
+import csv
+with open('data/data.json', 'r') as json_file:
+    json_data=json_file.read()
+installations = json.loads(json_data)['installations']
+with open('dataverse-installations.tsv', 'w', newline='') as tsvfile:
+    output = csv.writer(tsvfile, delimiter='\t')
+    header = [
+        'name',
+        'country',
+        'launch_year',
+        'hostname',
+        'continent',
+        'latitude',
+        'longitude',
+        'about_url',
+        'description',
+    ]
+    output.writerow(header)
+    for i in installations:
+        name = i['name']
+        country = i['country']
+        launch_year = i.get('launch_year', None)
+        continent = i['continent']
+        hostname = i['hostname']
+        latitude = i['lat']
+        longitude = i['lng']
+        about_url = i.get('about_url', None)
+        description = i['description']
+        output.writerow([
+            name,
+            country,
+            launch_year,
+            hostname,
+            continent,
+            latitude,
+            longitude,
+            about_url,
+            description,
+        ])


### PR DESCRIPTION
Closes #5 

Related to #7 

The idea with the "json2tsv" script in this pull request is to start treating Dataverse installations as tabular data.

The "data.json" file in this repo is used as input.

A TSV file called dataverse-installations.tsv is created, which can be used in Dataverse itself to play around with Dataverse features. Perhaps someday we can also have a Jupyter Notebook to explore the data further.

Here are some screenshots of playing with the TSV file in Dataverse 4.18.1:

![Screen Shot 2019-12-06 at 1 04 31 PM](https://user-images.githubusercontent.com/21006/70345238-8e660d80-1829-11ea-8e5d-7e70066847cc.png)

![Screen Shot 2019-12-06 at 12 59 59 PM](https://user-images.githubusercontent.com/21006/70345262-9e7ded00-1829-11ea-85a0-6886e2306c82.png)

![Screen Shot 2019-12-06 at 1 00 33 PM](https://user-images.githubusercontent.com/21006/70345233-8dcd7700-1829-11ea-99b4-be555ecd610d.png)
![Screen Shot 2019-12-06 at 1 01 11 PM](https://user-images.githubusercontent.com/21006/70345234-8dcd7700-1829-11ea-8ef3-cb34d9cd10c9.png)
![Screen Shot 2019-12-06 at 1 01 29 PM](https://user-images.githubusercontent.com/21006/70345237-8dcd7700-1829-11ea-9861-efeaa6b8d431.png)

![Screen Shot 2019-12-06 at 1 10 53 PM](https://user-images.githubusercontent.com/21006/70345438-15b38100-182a-11ea-8617-8d6a54af7a19.png)
![Screen Shot 2019-12-06 at 1 11 01 PM](https://user-images.githubusercontent.com/21006/70345439-15b38100-182a-11ea-879e-a780216b5bb6.png)
![Screen Shot 2019-12-06 at 1 12 17 PM](https://user-images.githubusercontent.com/21006/70345440-15b38100-182a-11ea-90ee-1421ae8999ff.png)

![Screen Shot 2019-12-06 at 1 13 24 PM](https://user-images.githubusercontent.com/21006/70345544-527f7800-182a-11ea-89b9-d9f0d07ce60b.png)
![Screen Shot 2019-12-06 at 1 14 08 PM](https://user-images.githubusercontent.com/21006/70345545-527f7800-182a-11ea-97b2-c2e2ab98d5b6.png)
