### PR TITLE
print hostname when on old map only (to add) #43

### DIFF
--- a/update-data.py
+++ b/update-data.py
@@ -125,6 +125,8 @@ for i in map_json['installations']:
             i['board'] = mydict[i['hostname']]['board']
         if mydict[i['hostname']]['contact_email'] != 'UNKNOWN':
             i['contact_email'] = mydict[i['hostname']]['contact_email']
+    else:
+        print('On the old map only (should be added): ' + i['hostname'])
     del i['id']
     del i['is_active']
     del i['slug']


### PR DESCRIPTION
Closes #43 

The output should look something like this:

```
$ python3 update-data.py 
On the old map only (should be added): dadosabertos.rnp.br
```

The idea is that this is our signal to add the installation to the new map using the spreadsheets mentioned in the README.