### PR TITLE
add script to find project board API URL #26

### DIFF
--- a/check-boards.py
+++ b/check-boards.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from urllib.request import Request, urlopen
+from urllib.parse import urlparse
+import csv
+import json
+import io
+
+api_url_by_html_url = {}
+iqss_projects_url = 'https://api.github.com/orgs/IQSS/projects'
+req = Request(iqss_projects_url)
+req.add_header('Accept', 'application/vnd.github.inertia-preview+json')
+response = urlopen(req)
+projects_out = json.loads(response.read().decode(response.info().get_param('charset') or 'utf-8'))
+for project in projects_out:
+    html_url = project['html_url']
+    api_url = project['url']
+    api_url_by_html_url[html_url] = api_url
+
+# Data maintained by IQSS.
+iqss_url = 'https://docs.google.com/spreadsheets/d/1l2R9D1FQy88qVzg2bI6L1LgplmM2l7pnMI80jdiz4fk/export?gid=639378778&format=tsv'
+response = urlopen(iqss_url)
+iqss_string = response.read().decode(response.info().get_param('charset') or 'utf-8')
+reader = csv.DictReader(io.StringIO(iqss_string), delimiter="\t")
+rows = [row for row in reader]
+for row in rows:
+    hostname = row['Installation hostname']
+    board_html_url = row['Project board under IQSS']
+    if not board_html_url:
+        continue
+    board_api_url = row['Project board API URL']
+    if not board_api_url:
+        board_api_url = api_url_by_html_url[board_html_url]
+        print(hostname + " created " + board_html_url + ' and "Project board API URL" should be updated to ' + board_api_url)


### PR DESCRIPTION
Closes #26

When you have a few installations that have missing "Project board API URL" like this...

![Screen Shot 2019-12-20 at 3 16 42 PM](https://user-images.githubusercontent.com/21006/71289722-ceee7c80-233b-11ea-9f59-0e5e17865e3d.png)

... running the script in this pull request should print output like this:

dataverse.harvard.edu created https://github.com/orgs/IQSS/projects/19 and "Project board API URL" should be updated to https://api.github.com/projects/3385335
dataverse.ird.fr created https://github.com/orgs/IQSS/projects/20 and "Project board API URL" should be updated to https://api.github.com/projects/3451425
dataverse.vtti.vt.edu created https://github.com/orgs/IQSS/projects/18 and "Project board API URL" should be updated to https://api.github.com/projects/3325795

The idea is to then go to the spreadsheet and fill in the missing "Project board API URL" cells.