### PR TITLE
Display copyright on map [ref #57]

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -21,7 +21,7 @@ const icon = L.divIcon({
 });
 
 var mymap = L.map('mapid', {
-  attributionControl: false,
+  attributionControl: true,
   zoomControl: false,
   zoomSnap: 0.25,
 }).setView([20, 10], 1.87);


### PR DESCRIPTION
Closes #57 give attribution to OpenStreetMap

Added copyright attribution to map.

![Screen Shot 2020-02-27 at 12 03 11 PM](https://user-images.githubusercontent.com/687227/75467191-4f8fb180-5959-11ea-875a-4a50413933ba.png)
