### PR TITLE
don't suggest that contact email won't be displayed

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-dataverse-repository-to-dataverse-map.md
+++ b/.github/ISSUE_TEMPLATE/add-dataverse-repository-to-dataverse-map.md
@@ -27,7 +27,7 @@ assignees: ''
 **A short description (few sentences) about the repository:**
 
 
-**Email address of repository contact (won't be displayed on the map):**
+**Email address of repository contact:**
 
 
 **DOI authority (such as 10.26193; if applicable; won't be displayed on the map):**


### PR DESCRIPTION
The email is public in a couple places...

- https://iqss.github.io/dataverse-installations/data/data.json
- spreadsheet: https://docs.google.com/spreadsheets/d/1bfsw7gnHlHerLXuk7YprUT68liHfcaMxs1rFciA-mEo/edit?usp=sharing

... and while it's true that it's not currently displayed on the map, we might someday and I don't want to give the impression that we never will. It's public data.

On a related note, we mention the contact email and spreadsheet here:

- https://github.com/IQSS/dataverse/pull/9241