### PR TITLE
add a GitHub Workflow to add bugs to the project board

### DIFF
--- a/.github/workflows/add_bugs_to_project.yml
+++ b/.github/workflows/add_bugs_to_project.yml
@@ -1,0 +1,18 @@
+name: Add bugs to project board
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add bug to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/IQSS/projects/34
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          labeled: Type: Bug


### PR DESCRIPTION
**What this PR does / why we need it**:

We'd like all new issues that are labeled as bugs to be automatically added to project 34. They will show up (among other places) in the "Open Bugs" view at https://github.com/orgs/IQSS/projects/34/views/46

**Special notes for your reviewer**:

Here are the docs: https://github.com/actions/add-to-project

**Suggestions on how to test this**:

Merge this. Create a new issue with `label:"Type: Bug"`. Check if it was added to the project. Find an existing issue that doesn't have `label:"Type: Bug"`. Add that label. See if it was added to the project.